### PR TITLE
Add optional dependency handling in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ Launch the FastAPI server:
 python -m architect.web
 ```
 
+## Running Tests
+
+Some tests rely on optional packages such as FastAPI and Pydantic. Install the
+``test`` extra to ensure all dependencies are available:
+
+```bash
+pip install -e .[test]
+pytest
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,19 @@ jinja2 = "^3.1"
 prometheus-client = "^0.20"
 sentry-sdk = "^1.40"
 
+[tool.poetry.extras]
+security = ["pydantic", "pydantic-settings"]
+web = ["fastapi", "uvicorn", "jinja2"]
+metrics = ["prometheus-client", "sentry-sdk"]
+llm = ["openai", "mistralai"]
+test = [
+    "fastapi",
+    "jinja2",
+    "pydantic",
+    "pydantic-settings",
+    "prometheus-client",
+]
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,10 @@
 import json
 from pathlib import Path
-from architect.cli import load_all_agents, save_state, STATE_PATH
 import pytest
+
+pytest.importorskip("typer")
+
+from architect.cli import load_all_agents, save_state, STATE_PATH
 
 def test_load_all_agents(tmp_path, monkeypatch):
     path = tmp_path / 'state.json'

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.importorskip("prometheus_client")
+
 from architect.metrics import agent_errors
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,3 +1,8 @@
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("pydantic_settings")
+
 from config.security import SecurityConfig
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,3 +1,9 @@
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("prometheus_client")
+pytest.importorskip("pydantic")
+
 from architect.web import app
 from architect.metrics import agent_invocations
 from fastapi.testclient import TestClient


### PR DESCRIPTION
## Summary
- skip tests if optional packages aren't installed using `pytest.importorskip`
- expose feature groups as extras in `pyproject.toml`
- document how to install optional test dependencies in `README`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684941d6ee7483339315ddbd56ad838e